### PR TITLE
Fix Incorrect middleware configuration in README.md #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ For sidekiq:
 
 ```
 Sidekiq.configure_server do |config|
-  config.server_middleware do |chain|
+  config.client_middleware do |chain|
     chain.add NewrelicGvl::Sidekiq::Middleware
   end
 end


### PR DESCRIPTION
For reference, the Sidekiq documentation on middleware creation can be found here: https://github.com/sidekiq/sidekiq/wiki/Middleware.

This PR addresses the issue described in [#1](https://github.com/gstark/newrelic_gvl/issues/1).