### PR TITLE
Fixes API design for Sidekiq middleware

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,1 @@
+[Navid EMAD](https://github.com/navidemad)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,7 @@ GEM
     unicode-display_width (2.4.2)
 
 PLATFORMS
+  arm64-darwin-22
   x86_64-darwin-21
 
 DEPENDENCIES
@@ -57,4 +58,4 @@ DEPENDENCIES
   standard (~> 1.3)
 
 BUNDLED WITH
-   2.3.15
+   2.4.7

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-*NOTE: This gem is still in development and untested in a production environment.*
+_NOTE: This gem is still in development and untested in a production environment._
 
 # NewRelic GVL Stats
 
@@ -16,18 +16,28 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 ## Usage
 
-For rails:
+### Rails
 
 ```
 config.middleware.use NewrelicGvl::Rack::Middleware
 ```
 
-For sidekiq:
+### Sidekiq Server:
 
 ```
 Sidekiq.configure_server do |config|
   config.server_middleware do |chain|
-    chain.add NewrelicGvl::Sidekiq::Middleware
+    chain.add NewrelicGvl::Sidekiq::ServerMiddleware
+  end
+end
+```
+
+### Sidekiq Client:
+
+```
+Sidekiq.configure_client do |config|
+  config.client_middleware do |chain|
+    chain.add NewrelicGvl::Sidekiq::ClientMiddleware
   end
 end
 ```
@@ -40,4 +50,4 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 
 ## Contributing
 
-Bug reports and pull requests are welcome on GitHub at https://github.com/gstark/newrelic_gvl.
+Bug reports and pull requests are welcome on GitHub at [https://github.com/gstark/newrelic\_gvl](https://github.com/gstark/newrelic_gvl).

--- a/lib/newrelic_gvl.rb
+++ b/lib/newrelic_gvl.rb
@@ -5,5 +5,6 @@ module NewrelicGvl
 end
 
 require_relative "newrelic_gvl/version"
-require_relative "newrelic_gvl/sidekiq/middleware"
+require_relative "newrelic_gvl/sidekiq/server_middleware"
+require_relative "newrelic_gvl/sidekiq/client_middleware"
 require_relative "newrelic_gvl/rack/middleware"

--- a/lib/newrelic_gvl/sidekiq/client_middleware.rb
+++ b/lib/newrelic_gvl/sidekiq/client_middleware.rb
@@ -1,0 +1,19 @@
+require "gvltools"
+
+module NewrelicGvl
+  module Sidekiq
+    class ClientMiddleware
+      include ::Sidekiq::ClientMiddleware if defined?(::Sidekiq::ClientMiddleware)
+
+      def call(*)
+        before = GVLTools::LocalTimer.monotonic_time
+
+        yield
+      ensure
+        wait_in_ms = (GVLTools::LocalTimer.monotonic_time - before) / 1_000_000.0
+
+        NewRelic::Agent.add_custom_attributes({gvl_wait: wait_in_ms})
+      end
+    end
+  end
+end

--- a/lib/newrelic_gvl/sidekiq/server_middleware.rb
+++ b/lib/newrelic_gvl/sidekiq/server_middleware.rb
@@ -2,10 +2,10 @@ require "gvltools"
 
 module NewrelicGvl
   module Sidekiq
-    class Middleware
-      include Sidekiq::ClientMiddleware if defined?(Sidekiq::ClientMiddleware)
+    class ServerMiddleware
+      include ::Sidekiq::ServerMiddleware if defined?(::Sidekiq::ServerMiddleware)
 
-      def call(_worker, _job, _queue, _redis_pool)
+      def call(*)
         before = GVLTools::LocalTimer.monotonic_time
 
         yield

--- a/test/sidekiq_client_middleware_spec.rb
+++ b/test/sidekiq_client_middleware_spec.rb
@@ -1,8 +1,8 @@
 require "test_helper"
 
-describe NewrelicGvl::Sidekiq::Middleware do
+describe NewrelicGvl::Sidekiq::ClientMiddleware do
   it "Yields to the middleware" do
-    middleware = NewrelicGvl::Sidekiq::Middleware.new
+    middleware = NewrelicGvl::Sidekiq::ClientMiddleware.new
 
     GVLTools::LocalTimer.expects(:monotonic_time).returns(0.0).twice
 
@@ -16,7 +16,7 @@ describe NewrelicGvl::Sidekiq::Middleware do
   end
 
   it "Sends the wait time to NewRelic" do
-    middleware = NewrelicGvl::Sidekiq::Middleware.new
+    middleware = NewrelicGvl::Sidekiq::ClientMiddleware.new
 
     GVLTools::LocalTimer.expects(:monotonic_time).returns(0.0).twice
 

--- a/test/sidekiq_server_middleware_spec.rb
+++ b/test/sidekiq_server_middleware_spec.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+describe NewrelicGvl::Sidekiq::ServerMiddleware do
+  it "Yields to the middleware" do
+    middleware = NewrelicGvl::Sidekiq::ServerMiddleware.new
+
+    GVLTools::LocalTimer.expects(:monotonic_time).returns(0.0).twice
+
+    value = 0
+
+    middleware.call(nil, nil, nil) do
+      value = 42
+    end
+
+    _(value).must_equal(42)
+  end
+
+  it "Sends the wait time to NewRelic" do
+    middleware = NewrelicGvl::Sidekiq::ServerMiddleware.new
+
+    GVLTools::LocalTimer.expects(:monotonic_time).returns(0.0).twice
+
+    NewRelic::Agent.expects(:add_custom_attributes).with({gvl_wait: 0.0})
+
+    middleware.call(nil, nil, nil) do
+      # Nothing to do
+    end
+  end
+end


### PR DESCRIPTION
Breaking API change: Adds NewrelicGvl::Sidekiq::ClientMiddleware and NewrelicGvl::Sidekiq::ServerMiddleware to allow for the instrumentation of client and server sidekiq middleware. The README has also been updated to note the new class names and usage.

Thanks to [Navid EMAD](https://github.com/navidemad) for the issue/PR concerning the incorrect API.